### PR TITLE
Add CLI parsing and initProject command

### DIFF
--- a/src/commands/initProject.ts
+++ b/src/commands/initProject.ts
@@ -1,0 +1,40 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+export interface InitOptions {
+  branch?: string;
+  install?: boolean;
+}
+
+function run(command: string, args: string[], options: { cwd?: string } = {}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'inherit', ...options });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+export async function initProject(projectName: string, options: InitOptions) {
+  if (fs.existsSync(projectName)) {
+    throw new Error(`Directory ${projectName} already exists.`);
+  }
+
+  const repoUrl = 'https://github.com/launchapp/launchapp.git';
+  const args = ['clone', repoUrl, projectName];
+  if (options.branch) {
+    args.push('-b', options.branch);
+  }
+
+  await run('git', args);
+
+  if (options.install) {
+    await run('npm', ['install'], { cwd: path.resolve(projectName) });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,47 @@
 #!/usr/bin/env node
+import { initProject } from './commands/initProject';
 
-console.log('create-launchapp cli');
+function showHelp() {
+  console.log(`Usage: create-launchapp <project-name> [--branch <branch>] [--install]`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const projectName = args[0];
+
+  if (!projectName || projectName.startsWith('--')) {
+    console.error('Error: project-name is required.');
+    showHelp();
+    process.exit(1);
+  }
+
+  let branch: string | undefined;
+  let install = false;
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--branch') {
+      if (i + 1 >= args.length) {
+        console.error('Error: --branch requires a value.');
+        showHelp();
+        process.exit(1);
+      }
+      branch = args[++i];
+    } else if (arg === '--install') {
+      install = true;
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      showHelp();
+      process.exit(1);
+    }
+  }
+
+  try {
+    await initProject(projectName, { branch, install });
+  } catch (err: any) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- parse CLI options in `src/index.ts`
- implement `initProject` command with git clone and optional npm install

## Testing
- `npx tsc --noEmit src/index.ts src/commands/initProject.ts` *(fails: Cannot find global value 'Promise', missing node types)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_683aa72f9da0833393e6030893cecbd9