### PR TITLE
Update Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
           check-latest: true


### PR DESCRIPTION
## Summary
- use Node 22 in CI and release workflows

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683b2d8360888333b6677c59b2f34779