### PR TITLE
Add createEnv defaults support

### DIFF
--- a/src/commands/createEnv.ts
+++ b/src/commands/createEnv.ts
@@ -1,0 +1,91 @@
+import inquirer from 'inquirer';
+import fs from 'fs';
+import path from 'path';
+
+export const ENV_VARS = [
+  'BETTER_AUTH_URL',
+  'BETTER_AUTH_SECRET',
+  'EMAIL_FROM',
+  'RESEND_API_KEY',
+  'DATABASE_URL',
+  'S3_ENDPOINT',
+  'S3_ACCESS_KEY',
+  'S3_SECRET_KEY',
+  'S3_BUCKET',
+  'S3_REGION',
+  'PUSH_PROVIDER',
+  'EXPO_ACCESS_TOKEN',
+  'FIREBASE_SERVICE_ACCOUNT_PATH',
+  'FIREBASE_DATABASE_URL',
+  'WEB_PUSH_PUBLIC_KEY',
+  'WEB_PUSH_PRIVATE_KEY',
+  'WEB_PUSH_SUBJECT',
+  'S3_BLOG_ASSETS_BUCKET',
+  'STRIPE_WEBHOOK_SECRET',
+  'STRIPE_SECRET_KEY',
+  'STRIPE_PUBLIC_KEY',
+  'BASE_API_PATH',
+  'APPLE_ISSUER_ID',
+  'APPLE_KEY_ID',
+  'APPLE_PRIVATE_KEY',
+  'GOOGLE_SERVICE_ACCOUNT_JSON',
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
+  'GITHUB_CLIENT_ID',
+  'GITHUB_CLIENT_SECRET',
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPEN_ROUTER_KEY'
+] as const;
+
+export const DEFAULT_VALUES: Record<string, string> = {
+  BETTER_AUTH_URL: 'http://localhost:5173',
+  BETTER_AUTH_SECRET: 'YOUR_SECURE_RANDOM_SECRET',
+  EMAIL_FROM: 'no-reply@yourdomain.com',
+  RESEND_API_KEY: 'YOUR_RESEND_API_KEY',
+  DATABASE_URL: 'postgresql://user:password@host:port/database',
+  S3_ENDPOINT: 'YOUR_S3_ENDPOINT_URL',
+  S3_ACCESS_KEY: 'YOUR_S3_ACCESS_KEY',
+  S3_SECRET_KEY: 'YOUR_S3_SECRET_KEY',
+  S3_BUCKET: 'your-bucket-name',
+  S3_REGION: 'your-s3-region',
+  PUSH_PROVIDER: 'expo',
+  EXPO_ACCESS_TOKEN: 'your_expo_access_token',
+  FIREBASE_SERVICE_ACCOUNT_PATH: 'path/to/service-account.json',
+  FIREBASE_DATABASE_URL: 'https://your-project.firebaseio.com',
+  WEB_PUSH_PUBLIC_KEY: 'your_vapid_public_key',
+  WEB_PUSH_PRIVATE_KEY: 'your_vapid_private_key',
+  WEB_PUSH_SUBJECT: 'mailto:your-email@example.com',
+  S3_BLOG_ASSETS_BUCKET: 'blog-assets',
+  STRIPE_WEBHOOK_SECRET: 'whsec_YOUR_STRIPE_WEBHOOK_SECRET',
+  STRIPE_SECRET_KEY: 'sk_test_YOUR_STRIPE_SECRET_KEY',
+  STRIPE_PUBLIC_KEY: 'pk_test_YOUR_STRIPE_PUBLIC_KEY',
+  BASE_API_PATH: 'http://localhost:5173/',
+  APPLE_ISSUER_ID: 'YOUR_APPLE_ISSUER_ID',
+  APPLE_KEY_ID: 'YOUR_APPLE_KEY_ID',
+  APPLE_PRIVATE_KEY: 'YOUR_APPLE_PRIVATE_KEY',
+  GOOGLE_SERVICE_ACCOUNT_JSON: 'YOUR_GOOGLE_SERVICE_ACCOUNT_JSON',
+  GOOGLE_CLIENT_ID: 'your-google-client-id',
+  GOOGLE_CLIENT_SECRET: 'your-google-client-secret',
+  GITHUB_CLIENT_ID: 'your-github-client-id',
+  GITHUB_CLIENT_SECRET: 'your-github-client-secret',
+  OPENAI_API_KEY: 'YOUR_OPENAI_API_KEY',
+  ANTHROPIC_API_KEY: 'YOUR_ANTHROPIC_API_KEY',
+  OPEN_ROUTER_KEY: 'YOUR_OPEN_ROUTER_KEY'
+};
+
+export async function createEnv(projectPath: string): Promise<void> {
+  const questions = ENV_VARS.map((name) => ({
+    type: 'input',
+    name,
+    message: `${name}:`,
+    default: process.env[name] ?? DEFAULT_VALUES[name]
+  }));
+
+  const answers = await inquirer.prompt(questions) as Record<string, string>;
+
+  const envContent = ENV_VARS.map((k) => `${k}=${answers[k] ?? ''}`).join('\n');
+
+  const envPath = path.join(projectPath, '.env');
+  await fs.promises.writeFile(envPath, envContent);
+}

--- a/test/createEnv.spec.ts
+++ b/test/createEnv.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+
+const answers: Record<string, string> = {};
+const promptMock = vi.fn().mockImplementation(() => Promise.resolve(answers));
+
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: promptMock
+  }
+}));
+
+const writeFileMock = vi.fn().mockResolvedValue(undefined);
+vi.mock('fs', () => ({
+  default: {
+    promises: { writeFile: writeFileMock }
+  }
+}));
+
+describe('createEnv', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.BETTER_AUTH_URL;
+  });
+
+  it('uses defaults and writes env file', async () => {
+    process.env.BETTER_AUTH_URL = 'http://env';
+    const mod = await import('../src/commands/createEnv');
+
+    mod.ENV_VARS.forEach(v => {
+      answers[v] = `${v}_VAL`;
+    });
+
+    await mod.createEnv('/proj');
+
+    const questions = promptMock.mock.calls[0][0] as Array<any>;
+    const betterAuth = questions.find(q => q.name === 'BETTER_AUTH_URL');
+    const pushProvider = questions.find(q => q.name === 'PUSH_PROVIDER');
+    expect(betterAuth.default).toBe('http://env');
+    expect(pushProvider.default).toBe('expo');
+
+    const envPath = path.join('/proj', '.env');
+    const expectedContent = mod.ENV_VARS.map(v => `${v}=${answers[v]}`).join('\n');
+    expect(writeFileMock).toHaveBeenCalledWith(envPath, expectedContent);
+  });
+});

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -63,12 +63,12 @@ describe('initProject', () => {
 
   it('executes git clone with branch', async () => {
     const { initProject, setSpawn } = await import('../src/commands/initProject');
-    setSpawn(spawnMock);
+    setSpawn(spawnMock as any);
     await initProject('proj', { branch: 'feature' });
 
     expect(spawnMock).toHaveBeenCalledWith(
       'git',
-      ['clone', 'https://github.com/launchapp/launchapp.git', 'proj', '-b', 'feature'],
+      ['clone', 'https://github.com/AudioGenius-ai/launchapp.dev.git', 'proj', '-b', 'feature'],
       { stdio: 'inherit' }
     );
   });


### PR DESCRIPTION
## Summary
- support a full env variable list with default values
- make `createEnv` use defaults and export constants
- update tests for defaults handling

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_683b32dc33ac8333b681c780fd18a142