### PR TITLE
Add create-env flag and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ The above command clones the Launchapp repository into `my-app` and runs `npm in
 
 - `--branch <branch>`: clone a specific branch from the Launchapp repository.
 - `--install`: automatically run `npm install` after cloning.
+- `--create-env`: generate a basic `.env` file after cloning.
+
+You can also run the environment setup separately:
+
+```bash
+npx create-launchapp create-env my-app
+```
 
 ## Future Extensibility
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dist"
   ],
   "dependencies": {
+    "inquirer": "^12.6.3",
     "open": "^10.1.2"
   },
   "scripts": {
@@ -20,10 +21,10 @@
     "release": "release-it"
   },
   "devDependencies": {
+    "@types/node": "^22.15.29",
+    "release-it": "^19.0.3",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.4",
-    "@types/node": "^22.15.29",
-    "release-it": "^19.0.3"
+    "vitest": "^3.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      inquirer:
+        specifier: ^12.6.3
+        version: 12.6.3(@types/node@22.15.29)
       open:
         specifier: ^10.1.2
         version: 10.1.2

--- a/src/commands/createEnv.ts
+++ b/src/commands/createEnv.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+
+export async function createEnv(projectName: string) {
+  const envPath = path.join(projectName, '.env');
+  if (fs.existsSync(envPath)) {
+    console.log(`Environment file already exists at ${envPath}`);
+    return;
+  }
+  fs.writeFileSync(envPath, 'LAUNCHAPP_ENV=development\n');
+  console.log(`Created environment file at ${envPath}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,28 @@
 #!/usr/bin/env node
 import { initProject } from './commands/initProject';
+import { createEnv } from './commands/createEnv';
 
 function showHelp() {
-  console.log(`Usage: create-launchapp <project-name> [--branch <branch>] [--install]`);
+  console.log(
+    `Usage: create-launchapp <project-name> [--branch <branch>] [--install] [--create-env]\n` +
+      `       create-launchapp create-env <project-name>`
+  );
 }
 
 async function main() {
   const args = process.argv.slice(2);
+
+  if (args[0] === 'create-env') {
+    const project = args[1];
+    if (!project) {
+      console.error('Error: project-name is required for create-env.');
+      showHelp();
+      process.exit(1);
+    }
+    await createEnv(project);
+    return;
+  }
+
   const projectName = args[0];
 
   if (!projectName || projectName.startsWith('--')) {
@@ -17,6 +33,7 @@ async function main() {
 
   let branch: string | undefined;
   let install = false;
+  let createEnvAfter = false;
 
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
@@ -29,6 +46,8 @@ async function main() {
       branch = args[++i];
     } else if (arg === '--install') {
       install = true;
+    } else if (arg === '--create-env') {
+      createEnvAfter = true;
     } else {
       console.error(`Unknown argument: ${arg}`);
       showHelp();
@@ -38,6 +57,9 @@ async function main() {
 
   try {
     await initProject(projectName, { branch, install });
+    if (createEnvAfter) {
+      await createEnv(projectName);
+    }
   } catch (err: any) {
     console.error(err.message);
     process.exit(1);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -12,7 +12,8 @@ const spawnMock = vi.fn(() => ({
 // Mock fs.existsSync to avoid filesystem side effects
 vi.mock('fs', () => ({
   default: {
-    existsSync: vi.fn().mockReturnValue(false)
+    existsSync: vi.fn().mockReturnValue(false),
+    writeFileSync: vi.fn()
   }
 }));
 
@@ -31,13 +32,16 @@ describe('CLI argument parsing', () => {
     process.argv = originalArgv.slice();
     exitSpy.mockRestore();
     vi.unmock('../src/commands/initProject');
+    vi.unmock('../src/commands/createEnv');
   });
 
   it('passes options to initProject', async () => {
     const mod = await import('../src/commands/initProject');
     const initProjectMock = vi.spyOn(mod, 'initProject').mockResolvedValue(undefined);
+    const envMod = await import('../src/commands/createEnv');
+    const createEnvMock = vi.spyOn(envMod, 'createEnv').mockResolvedValue(undefined);
 
-    process.argv = ['node', 'create-launchapp', 'myapp', '--branch', 'dev', '--install'];
+    process.argv = ['node', 'create-launchapp', 'myapp', '--branch', 'dev', '--install', '--create-env'];
     try {
       await import('../src/index');
     } catch (e) {
@@ -45,6 +49,21 @@ describe('CLI argument parsing', () => {
     }
 
     expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: 'dev', install: true });
+    expect(createEnvMock).toHaveBeenCalledWith('myapp');
+  });
+
+  it('supports the create-env subcommand', async () => {
+    const envMod = await import('../src/commands/createEnv');
+    const createEnvMock = vi.spyOn(envMod, 'createEnv').mockResolvedValue(undefined);
+
+    process.argv = ['node', 'create-launchapp', 'create-env', 'proj'];
+    try {
+      await import('../src/index');
+    } catch (e) {
+      // process.exit throws
+    }
+
+    expect(createEnvMock).toHaveBeenCalledWith('proj');
   });
 });
 
@@ -52,6 +71,7 @@ describe('initProject', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unmock('../src/commands/initProject');
+    vi.unmock('../src/commands/createEnv');
   });
 
   afterEach(async () => {
@@ -59,6 +79,7 @@ describe('initProject', () => {
     const { spawn } = await import('child_process');
     setSpawn(spawn);
     vi.clearAllMocks();
+    vi.unmock('../src/commands/createEnv');
   });
 
   it('executes git clone with branch', async () => {


### PR DESCRIPTION
## Summary
- add a `createEnv` command to generate a basic `.env` file
- support `--create-env` flag and `create-env` subcommand
- update CLI usage and README docs
- test new flag and subcommand handling

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683b75dca81883338c1aa26609a5ca1c