### PR TITLE
Add interactive env setup command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "inquirer": "^9.0.0"
+  },
   "scripts": {
     "build": "tsup",
     "prepare": "tsup",

--- a/src/commands/createEnv.ts
+++ b/src/commands/createEnv.ts
@@ -1,0 +1,89 @@
+import inquirer from 'inquirer';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+export interface CreateEnvOptions {
+  projectRoot: string;
+}
+
+export async function createEnv(options: CreateEnvOptions): Promise<void> {
+  const answers = await inquirer.prompt<Record<string, string>>([
+    {
+      type: 'list',
+      name: 'pushProvider',
+      message: 'Choose your push provider:',
+      choices: [
+        { name: 'Expo', value: 'expo' },
+        { name: 'Firebase', value: 'firebase' },
+        { name: 'Web Push', value: 'web' },
+        { name: 'None', value: 'none' }
+      ]
+    },
+    {
+      type: 'input',
+      name: 'expoToken',
+      message: 'Expo access token:',
+      when: (a) => a.pushProvider === 'expo'
+    },
+    {
+      type: 'input',
+      name: 'firebaseKey',
+      message: 'Firebase server key:',
+      when: (a) => a.pushProvider === 'firebase'
+    },
+    {
+      type: 'input',
+      name: 'webPushPublicKey',
+      message: 'Web push public key:',
+      when: (a) => a.pushProvider === 'web'
+    },
+    {
+      type: 'input',
+      name: 'webPushPrivateKey',
+      message: 'Web push private key:',
+      when: (a) => a.pushProvider === 'web'
+    },
+    {
+      type: 'input',
+      name: 'stripePublicKey',
+      message: 'Stripe publishable key:'
+    },
+    {
+      type: 'input',
+      name: 'stripeSecretKey',
+      message: 'Stripe secret key:'
+    }
+  ]);
+
+  const env: Record<string, string> = {
+    BETTER_AUTH_SECRET: crypto.randomBytes(32).toString('hex'),
+    STRIPE_PUBLIC_KEY: answers.stripePublicKey,
+    STRIPE_SECRET_KEY: answers.stripeSecretKey,
+    PUSH_PROVIDER: answers.pushProvider
+  };
+
+  if (answers.pushProvider === 'expo') {
+    env.EXPO_ACCESS_TOKEN = answers.expoToken;
+  } else if (answers.pushProvider === 'firebase') {
+    env.FIREBASE_SERVER_KEY = answers.firebaseKey;
+  } else if (answers.pushProvider === 'web') {
+    env.WEB_PUSH_PUBLIC_KEY = answers.webPushPublicKey;
+    env.WEB_PUSH_PRIVATE_KEY = answers.webPushPrivateKey;
+  }
+
+  let content = '';
+  for (const [key, value] of Object.entries(env)) {
+    if (value) {
+      content += `${key}=${value}\n`;
+    }
+  }
+
+  const envPath = path.join(options.projectRoot, '.env');
+  fs.writeFileSync(envPath, content);
+
+  const mobilePath = path.join(options.projectRoot, 'mobile');
+  if (fs.existsSync(mobilePath)) {
+    fs.writeFileSync(path.join(mobilePath, '.env'), content);
+  }
+}

--- a/src/types/inquirer.d.ts
+++ b/src/types/inquirer.d.ts
@@ -1,0 +1,14 @@
+declare module 'inquirer' {
+  export interface Question {
+    type?: string;
+    name: string;
+    message?: string;
+    choices?: any;
+    when?: (answers: any) => boolean;
+  }
+
+  export function prompt<T = any>(questions: Question[]): Promise<T>;
+
+  const _default: { prompt: typeof prompt };
+  export default _default;
+}

--- a/test/createEnv.spec.ts
+++ b/test/createEnv.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+var writeFileMock: any;
+var existsSyncMock: any;
+vi.mock('fs', () => {
+  writeFileMock = vi.fn();
+  existsSyncMock = vi.fn();
+  return {
+    default: {
+      writeFileSync: writeFileMock,
+      existsSync: existsSyncMock,
+    },
+  };
+});
+
+var promptMock: any;
+vi.mock('inquirer', () => {
+  promptMock = vi.fn();
+  return { default: { prompt: promptMock } };
+});
+
+import crypto from 'crypto';
+
+import { createEnv } from '../src/commands/createEnv';
+
+describe('createEnv', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(crypto, 'randomBytes').mockReturnValue(Buffer.from('12345678901234567890123456789012'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes env files for expo provider and mobile app', async () => {
+    promptMock.mockResolvedValue({
+      pushProvider: 'expo',
+      expoToken: 'token',
+      stripePublicKey: 'pub',
+      stripeSecretKey: 'sec'
+    });
+    existsSyncMock.mockImplementation((p: string) => p.includes('mobile'));
+
+    await createEnv({ projectRoot: '/app' });
+
+    const expected =
+      'BETTER_AUTH_SECRET=3132333435363738393031323334353637383930313233343536373839303132\n' +
+      'STRIPE_PUBLIC_KEY=pub\n' +
+      'STRIPE_SECRET_KEY=sec\n' +
+      'PUSH_PROVIDER=expo\n' +
+      'EXPO_ACCESS_TOKEN=token\n';
+
+    expect(writeFileMock).toHaveBeenCalledWith('/app/.env', expected);
+    expect(writeFileMock).toHaveBeenCalledWith('/app/mobile/.env', expected);
+  });
+
+  it('skips expo variables when firebase is chosen', async () => {
+    promptMock.mockResolvedValue({
+      pushProvider: 'firebase',
+      firebaseKey: 'fkey',
+      stripePublicKey: 'pub',
+      stripeSecretKey: 'sec'
+    });
+    existsSyncMock.mockReturnValue(false);
+
+    await createEnv({ projectRoot: '/app' });
+
+    const result = writeFileMock.mock.calls[0][1] as string;
+    expect(result).toContain('PUSH_PROVIDER=firebase');
+    expect(result).toContain('FIREBASE_SERVER_KEY=fkey');
+    expect(result).not.toContain('EXPO_ACCESS_TOKEN');
+  });
+});


### PR DESCRIPTION
## Summary
- add interactive `.env` generator with provider-specific prompts
- provide TypeScript declaration for `inquirer`
- add new dependency `inquirer`
- test environment creation logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683b948f41ac8333af9af7550b87b0af