### PR TITLE
Add create-env command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ The above command clones the Launchapp repository into `my-app` and runs `npm in
 
 - `--branch <branch>`: clone a specific branch from the Launchapp repository.
 - `--install`: automatically run `npm install` after cloning.
+- `--create-env`: generate a default `.env` file after cloning.
+
+### Subcommands
+
+- `create-env <projectDir>`: create the `.env` file in an existing project directory.
 
 ## Future Extensibility
 

--- a/src/commands/createEnv.ts
+++ b/src/commands/createEnv.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+export async function createEnv(projectDir: string) {
+  const envPath = path.resolve(projectDir, '.env');
+  if (fs.existsSync(envPath)) {
+    throw new Error(`.env already exists in ${projectDir}`);
+  }
+  await fs.promises.writeFile(envPath, 'NODE_ENV=development\n');
+  console.log(`Created .env at ${envPath}`);
+}

--- a/src/commands/initProject.ts
+++ b/src/commands/initProject.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { createEnv } from './createEnv';
 
 // Allow overriding spawn for testing
 export let spawnFn = spawn;
@@ -11,6 +12,7 @@ import path from 'path';
 export interface InitOptions {
   branch?: string;
   install?: boolean;
+  createEnv?: boolean;
 }
 
 export function run(command: string, args: string[], options: { cwd?: string } = {}): Promise<void> {
@@ -39,6 +41,10 @@ export async function initProject(projectName: string, options: InitOptions) {
   }
 
   await run('git', args);
+
+  if (options.createEnv) {
+    await createEnv(path.resolve(projectName));
+  }
 
   if (options.install) {
     await run('npm', ['install'], { cwd: path.resolve(projectName) });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,34 @@
 #!/usr/bin/env node
 import { initProject } from './commands/initProject';
+import { createEnv } from './commands/createEnv';
 
 function showHelp() {
-  console.log(`Usage: create-launchapp <project-name> [--branch <branch>] [--install]`);
+  console.log(`Usage:`);
+  console.log(`  create-launchapp <project-name> [--branch <branch>] [--install] [--create-env]`);
+  console.log(`  create-launchapp create-env <projectDir>`);
 }
 
 async function main() {
   const args = process.argv.slice(2);
-  const projectName = args[0];
+  const first = args[0];
+
+  if (first === 'create-env') {
+    const projectDir = args[1];
+    if (!projectDir || projectDir.startsWith('--')) {
+      console.error('Error: projectDir is required.');
+      showHelp();
+      process.exit(1);
+    }
+    try {
+      await createEnv(projectDir);
+    } catch (err: any) {
+      console.error(err.message);
+      process.exit(1);
+    }
+    return;
+  }
+
+  const projectName = first;
 
   if (!projectName || projectName.startsWith('--')) {
     console.error('Error: project-name is required.');
@@ -17,6 +38,7 @@ async function main() {
 
   let branch: string | undefined;
   let install = false;
+  let createEnvFlag = false;
 
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
@@ -29,6 +51,8 @@ async function main() {
       branch = args[++i];
     } else if (arg === '--install') {
       install = true;
+    } else if (arg === '--create-env') {
+      createEnvFlag = true;
     } else {
       console.error(`Unknown argument: ${arg}`);
       showHelp();
@@ -37,7 +61,7 @@ async function main() {
   }
 
   try {
-    await initProject(projectName, { branch, install });
+    await initProject(projectName, { branch, install, createEnv: createEnvFlag });
   } catch (err: any) {
     console.error(err.message);
     process.exit(1);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
 
 // Helper to simulate successful spawn
 const spawnMock = vi.fn(() => ({
@@ -31,6 +32,7 @@ describe('CLI argument parsing', () => {
     process.argv = originalArgv.slice();
     exitSpy.mockRestore();
     vi.unmock('../src/commands/initProject');
+    vi.unmock('../src/commands/createEnv');
   });
 
   it('passes options to initProject', async () => {
@@ -44,7 +46,35 @@ describe('CLI argument parsing', () => {
       // process.exit throws
     }
 
-    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: 'dev', install: true });
+    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: 'dev', install: true, createEnv: false });
+  });
+
+  it('runs createEnv for subcommand', async () => {
+    const mod = await import('../src/commands/createEnv');
+    const createEnvMock = vi.spyOn(mod, 'createEnv').mockResolvedValue(undefined);
+
+    process.argv = ['node', 'create-launchapp', 'create-env', 'dir'];
+    try {
+      await import('../src/index');
+    } catch (e) {
+      // process.exit throws
+    }
+
+    expect(createEnvMock).toHaveBeenCalledWith('dir');
+  });
+
+  it('passes --create-env to initProject', async () => {
+    const mod = await import('../src/commands/initProject');
+    const initProjectMock = vi.spyOn(mod, 'initProject').mockResolvedValue(undefined);
+
+    process.argv = ['node', 'create-launchapp', 'myapp', '--create-env'];
+    try {
+      await import('../src/index');
+    } catch (e) {
+      // process.exit throws
+    }
+
+    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: undefined, install: false, createEnv: true });
   });
 });
 
@@ -71,5 +101,16 @@ describe('initProject', () => {
       ['clone', 'https://github.com/launchapp/launchapp.git', 'proj', '-b', 'feature'],
       { stdio: 'inherit' }
     );
+  });
+
+  it('calls createEnv when option enabled', async () => {
+    const { initProject, setSpawn } = await import('../src/commands/initProject');
+    const createEnvMod = await import('../src/commands/createEnv');
+    const createEnvSpy = vi.spyOn(createEnvMod, 'createEnv').mockResolvedValue(undefined);
+    setSpawn(spawnMock);
+
+    await initProject('proj', { createEnv: true });
+
+    expect(createEnvSpy).toHaveBeenCalledWith(path.resolve('proj'));
   });
 });


### PR DESCRIPTION
## Summary
- add `createEnv` command
- support `create-env` subcommand in CLI
- call `createEnv` from `initProject` when `--create-env` flag is present
- document new option and subcommand
- test subcommand and flag behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b948fdfa48333a3a273cb922e0faf