### PR TITLE
Add env config helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ npx create-launchapp my-app --install
 ```
 
 The above command clones the Launchapp repository into `my-app` and runs `npm install` inside the created directory.
+An `.env.example` file is also generated using predefined environment variable definitions.
 
 ### Options
 
 - `--branch <branch>`: clone a specific branch from the Launchapp repository.
 - `--install`: automatically run `npm install` after cloning.
+- `--env`: prompt for environment variables using defaults and create a `.env` file.
 
 ## Future Extensibility
 

--- a/src/commands/initProject.ts
+++ b/src/commands/initProject.ts
@@ -7,10 +7,12 @@ export function setSpawn(fn: typeof spawn) {
 }
 import fs from 'fs';
 import path from 'path';
+import { generateEnvExample, promptAndWriteEnv } from '../env/manageEnv';
 
 export interface InitOptions {
   branch?: string;
   install?: boolean;
+  promptEnv?: boolean;
 }
 
 export function run(command: string, args: string[], options: { cwd?: string } = {}): Promise<void> {
@@ -39,6 +41,11 @@ export async function initProject(projectName: string, options: InitOptions) {
   }
 
   await run('git', args);
+
+  generateEnvExample(projectName);
+  if (options.promptEnv) {
+    await promptAndWriteEnv(projectName);
+  }
 
   if (options.install) {
     await run('npm', ['install'], { cwd: path.resolve(projectName) });

--- a/src/env/manageEnv.ts
+++ b/src/env/manageEnv.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { ENV_VARIABLES } from './variables';
+
+export function generateEnvExample(projectDir: string) {
+  const lines = ENV_VARIABLES.map(v => `# ${v.description}\n${v.name}=${v.default ?? ''}`);
+  fs.writeFileSync(path.join(projectDir, '.env.example'), lines.join('\n') + '\n');
+}
+
+export async function promptAndWriteEnv(projectDir: string) {
+  const { default: inquirer } = await import('inquirer');
+  const questions = ENV_VARIABLES.map(v => ({
+    type: 'input',
+    name: v.name,
+    message: `${v.name} (${v.description})`,
+    default: v.default
+  }));
+  const answers = await inquirer.prompt<Record<string, string>>(questions);
+  const lines = ENV_VARIABLES.map(v => `${v.name}=${answers[v.name] ?? ''}`);
+  fs.writeFileSync(path.join(projectDir, '.env'), lines.join('\n') + '\n');
+}

--- a/src/env/variables.ts
+++ b/src/env/variables.ts
@@ -1,0 +1,18 @@
+export interface EnvVariable {
+  name: string;
+  default?: string;
+  description: string;
+}
+
+export const ENV_VARIABLES: EnvVariable[] = [
+  {
+    name: 'DATABASE_URL',
+    default: '',
+    description: 'Database connection string'
+  },
+  {
+    name: 'PORT',
+    default: '3000',
+    description: 'Port the application will run on'
+  }
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@
 import { initProject } from './commands/initProject';
 
 function showHelp() {
-  console.log(`Usage: create-launchapp <project-name> [--branch <branch>] [--install]`);
+  console.log(
+    `Usage: create-launchapp <project-name> [--branch <branch>] [--install] [--env]`
+  );
 }
 
 async function main() {
@@ -17,6 +19,7 @@ async function main() {
 
   let branch: string | undefined;
   let install = false;
+  let promptEnv = false;
 
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
@@ -29,6 +32,8 @@ async function main() {
       branch = args[++i];
     } else if (arg === '--install') {
       install = true;
+    } else if (arg === '--env') {
+      promptEnv = true;
     } else {
       console.error(`Unknown argument: ${arg}`);
       showHelp();
@@ -37,7 +42,7 @@ async function main() {
   }
 
   try {
-    await initProject(projectName, { branch, install });
+    await initProject(projectName, { branch, install, promptEnv });
   } catch (err: any) {
     console.error(err.message);
     process.exit(1);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -12,7 +12,8 @@ const spawnMock = vi.fn(() => ({
 // Mock fs.existsSync to avoid filesystem side effects
 vi.mock('fs', () => ({
   default: {
-    existsSync: vi.fn().mockReturnValue(false)
+    existsSync: vi.fn().mockReturnValue(false),
+    writeFileSync: vi.fn()
   }
 }));
 
@@ -37,14 +38,14 @@ describe('CLI argument parsing', () => {
     const mod = await import('../src/commands/initProject');
     const initProjectMock = vi.spyOn(mod, 'initProject').mockResolvedValue(undefined);
 
-    process.argv = ['node', 'create-launchapp', 'myapp', '--branch', 'dev', '--install'];
+    process.argv = ['node', 'create-launchapp', 'myapp', '--branch', 'dev', '--install', '--env'];
     try {
       await import('../src/index');
     } catch (e) {
       // process.exit throws
     }
 
-    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: 'dev', install: true });
+    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: 'dev', install: true, promptEnv: true });
   });
 });
 


### PR DESCRIPTION
## Summary
- add env variable definitions and management helpers
- generate `.env.example` and optional `.env` via `--env`
- update README
- test CLI with `--env`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b9490c39483339e8f169efe8d98fd