### PR TITLE
Add environment setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ The above command clones the Launchapp repository into `my-app` and runs `npm in
 - `--branch <branch>`: clone a specific branch from the Launchapp repository.
 - `--install`: automatically run `npm install` after cloning.
 
+### Environment Setup
+
+Once the project is created you can generate a `.env` file by running the
+`createEnv` command:
+
+```ts
+import { createEnv } from 'create-launchapp';
+
+await createEnv();
+```
+
+The script asks about push provider, payments and mobile configuration then
+creates a `.env` file (and optional `mobile/.env`).
+
 ## Future Extensibility
 
 The CLI is designed to be extended with additional commands. A planned feature is `add-plugin` to easily install and configure Launchapp plugins within an existing project.

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
     "vitest": "^1.0.0",
     "@types/node": "^20.0.0",
     "release-it": "^17.0.0"
+  },
+  "dependencies": {
+    "inquirer": "^9.0.0",
+    "web-push": "^3.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       open:
         specifier: ^10.1.2
         version: 10.1.2
+      web-push:
+        specifier: ^3.5.0
+        version: 3.6.7
     devDependencies:
       '@types/node':
         specifier: ^22.15.29
@@ -707,6 +710,9 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -728,8 +734,14 @@ packages:
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
+  bn.js@4.12.2:
+    resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
+
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -862,6 +874,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
@@ -977,6 +992,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -988,6 +1007,9 @@ packages:
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inquirer@12.6.3:
     resolution: {integrity: sha512-eX9beYAjr1MqYsIjx1vAheXsRk1jbZRvHLcBu5nA9wX0rXR1IfCZLnVLp4Ym4mrhqmh7AuANwcdtgQ291fZDfQ==}
@@ -1059,6 +1081,12 @@ packages:
 
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1139,9 +1167,15 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -1348,6 +1382,9 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1596,6 +1633,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -2137,6 +2179,13 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.2
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
@@ -2153,9 +2202,13 @@ snapshots:
 
   before-after-hook@3.0.2: {}
 
+  bn.js@4.12.2: {}
+
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bundle-name@4.1.0:
     dependencies:
@@ -2265,6 +2318,10 @@ snapshots:
   dotenv@16.5.0: {}
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   emoji-regex@10.4.0: {}
 
@@ -2436,6 +2493,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
@@ -2448,6 +2507,8 @@ snapshots:
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
 
   inquirer@12.6.3(@types/node@22.15.29):
     dependencies:
@@ -2512,6 +2573,17 @@ snapshots:
 
   jsbn@1.1.0: {}
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.0:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -2565,9 +2637,13 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
+
+  minimist@1.2.8: {}
 
   minipass@7.1.2: {}
 
@@ -2823,6 +2899,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   semver@7.7.2: {}
@@ -3050,6 +3128,16 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.0
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@4.0.2: {}
 

--- a/src/commands/createEnv.ts
+++ b/src/commands/createEnv.ts
@@ -1,0 +1,103 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import inquirer from 'inquirer';
+import webPush from 'web-push';
+
+export interface CreateEnvOptions {
+  cwd?: string;
+}
+
+export async function createEnv(options: CreateEnvOptions = {}) {
+  const cwd = options.cwd || process.cwd();
+
+  const answers = await inquirer.prompt([
+    {
+      type: 'input',
+      name: 'authUrl',
+      message: 'Better Auth base URL',
+      default: 'http://localhost:5173'
+    },
+    {
+      type: 'list',
+      name: 'pushProvider',
+      message: 'Select push notification provider',
+      choices: [
+        { name: 'None', value: 'none' },
+        { name: 'Expo', value: 'expo' },
+        { name: 'Firebase', value: 'firebase' },
+        { name: 'Web Push', value: 'web' }
+      ],
+      default: 'expo'
+    },
+    {
+      type: 'confirm',
+      name: 'payments',
+      message: 'Enable payments?',
+      default: false
+    },
+    {
+      type: 'confirm',
+      name: 'mobile',
+      message: 'Configure mobile app?',
+      default: false
+    }
+  ]);
+
+  const env: Record<string, string> = {
+    BETTER_AUTH_URL: answers.authUrl,
+    BETTER_AUTH_SECRET: crypto.randomBytes(32).toString('hex'),
+    EMAIL_FROM: 'no-reply@yourdomain.com',
+    RESEND_API_KEY: '',
+    DATABASE_URL: '',
+    S3_ENDPOINT: '',
+    S3_ACCESS_KEY: '',
+    S3_SECRET_KEY: '',
+    S3_BUCKET: '',
+    S3_REGION: '',
+    PUSH_PROVIDER: answers.pushProvider,
+    EXPO_ACCESS_TOKEN: '',
+    FIREBASE_SERVICE_ACCOUNT_PATH: '',
+    FIREBASE_DATABASE_URL: '',
+    WEB_PUSH_PUBLIC_KEY: '',
+    WEB_PUSH_PRIVATE_KEY: '',
+    WEB_PUSH_SUBJECT: 'mailto:your-email@example.com',
+    S3_BLOG_ASSETS_BUCKET: 'blog-assets',
+    STRIPE_WEBHOOK_SECRET: '',
+    STRIPE_SECRET_KEY: '',
+    STRIPE_PUBLIC_KEY: '',
+    BASE_API_PATH: 'http://localhost:5173/',
+    APPLE_ISSUER_ID: '',
+    APPLE_KEY_ID: '',
+    APPLE_PRIVATE_KEY: '',
+    GOOGLE_SERVICE_ACCOUNT_JSON: '',
+    GOOGLE_CLIENT_ID: '',
+    GOOGLE_CLIENT_SECRET: '',
+    GITHUB_CLIENT_ID: '',
+    GITHUB_CLIENT_SECRET: '',
+    OPENAI_API_KEY: '',
+    ANTHROPIC_API_KEY: '',
+    OPEN_ROUTER_KEY: '',
+    PAYMENTS_ENABLED: answers.payments ? 'true' : 'false'
+  };
+
+  if (answers.pushProvider === 'web') {
+    const { publicKey, privateKey } = webPush.generateVAPIDKeys();
+    env.WEB_PUSH_PUBLIC_KEY = publicKey;
+    env.WEB_PUSH_PRIVATE_KEY = privateKey;
+  }
+
+  const envLines = Object.entries(env)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+
+  const envPath = path.join(cwd, '.env');
+  fs.writeFileSync(envPath, envLines, { encoding: 'utf8' });
+
+  if (answers.mobile) {
+    const mobileDir = path.join(cwd, 'mobile');
+    fs.mkdirSync(mobileDir, { recursive: true });
+    const mobileEnvPath = path.join(mobileDir, '.env');
+    fs.writeFileSync(mobileEnvPath, envLines, { encoding: 'utf8' });
+  }
+}


### PR DESCRIPTION
## Summary
- add new command `createEnv` for interactive environment configuration
- generate `BETTER_AUTH_SECRET` and optional VAPID keys
- account for all environment variables including push providers and payment options
- write values to `.env` and `mobile/.env`

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_683bb00794a883338301424308d8589a