### PR TITLE
Add repo url option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The above command clones the Launchapp repository into `my-app` and runs `npm in
 
 - `--branch <branch>`: clone a specific branch from the Launchapp repository.
 - `--install`: automatically run `npm install` after cloning.
+- `--repo <url>`: specify an alternative git repository to clone.
 
 ## Future Extensibility
 

--- a/src/commands/initProject.ts
+++ b/src/commands/initProject.ts
@@ -10,6 +10,7 @@ import path from 'path';
 
 export interface InitOptions {
   branch?: string;
+  repoUrl?: string;
   install?: boolean;
 }
 
@@ -32,7 +33,7 @@ export async function initProject(projectName: string, options: InitOptions) {
     throw new Error(`Directory ${projectName} already exists.`);
   }
 
-  const repoUrl = 'https://github.com/launchapp/launchapp.git';
+  const repoUrl = options.repoUrl || 'https://github.com/launchapp/launchapp.git';
   const args = ['clone', repoUrl, projectName];
   if (options.branch) {
     args.push('-b', options.branch);

--- a/src/commands/initProject.ts
+++ b/src/commands/initProject.ts
@@ -35,7 +35,7 @@ export async function initProject(projectName: string, options: InitOptions) {
     throw new Error(`Directory ${projectName} already exists.`);
   }
 
-  const repoUrl = options.repoUrl || 'https://github.com/launchapp/launchapp.git';
+  const repoUrl = options.repoUrl || 'https://github.com/AudioGenius-ai/launchapp.dev.git';
   const args = ['clone', repoUrl, projectName];
   const branch = options.branch ?? 'main';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@
 import { initProject } from './commands/initProject';
 
 function showHelp() {
-  console.log(`Usage: create-launchapp <project-name> [--branch <branch>] [--install]`);
+  console.log(
+    `Usage: create-launchapp <project-name> [--branch <branch>] [--repo <url>] [--install]`
+  );
 }
 
 async function main() {
@@ -16,6 +18,7 @@ async function main() {
   }
 
   let branch: string | undefined;
+  let repoUrl: string | undefined;
   let install = false;
 
   for (let i = 1; i < args.length; i++) {
@@ -27,6 +30,13 @@ async function main() {
         process.exit(1);
       }
       branch = args[++i];
+    } else if (arg === '--repo') {
+      if (i + 1 >= args.length) {
+        console.error('Error: --repo requires a value.');
+        showHelp();
+        process.exit(1);
+      }
+      repoUrl = args[++i];
     } else if (arg === '--install') {
       install = true;
     } else {
@@ -37,7 +47,7 @@ async function main() {
   }
 
   try {
-    await initProject(projectName, { branch, install });
+    await initProject(projectName, { branch, repoUrl, install });
   } catch (err: any) {
     console.error(err.message);
     process.exit(1);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -44,7 +44,21 @@ describe('CLI argument parsing', () => {
       // process.exit throws
     }
 
-    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: 'dev', install: true });
+    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: 'dev', repoUrl: undefined, install: true });
+  });
+
+  it('passes repo option to initProject', async () => {
+    const mod = await import('../src/commands/initProject');
+    const initProjectMock = vi.spyOn(mod, 'initProject').mockResolvedValue(undefined);
+
+    process.argv = ['node', 'create-launchapp', 'myapp', '--repo', 'https://example.com/repo.git'];
+    try {
+      await import('../src/index');
+    } catch (e) {
+      // process.exit throws
+    }
+
+    expect(initProjectMock).toHaveBeenCalledWith('myapp', { repoUrl: 'https://example.com/repo.git', branch: undefined, install: false });
   });
 });
 
@@ -69,6 +83,18 @@ describe('initProject', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       'git',
       ['clone', 'https://github.com/launchapp/launchapp.git', 'proj', '-b', 'feature'],
+      { stdio: 'inherit' }
+    );
+  });
+
+  it('executes git clone with custom repo', async () => {
+    const { initProject, setSpawn } = await import('../src/commands/initProject');
+    setSpawn(spawnMock);
+    await initProject('proj', { repoUrl: 'https://example.com/custom.git' });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'git',
+      ['clone', 'https://example.com/custom.git', 'proj'],
       { stdio: 'inherit' }
     );
   });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -129,7 +129,7 @@ describe('CLI argument parsing', () => {
       // process.exit throws
     }
 
-    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: 'dev', repoUrl: undefined, branch: undefined, install: true });
+    expect(createEnvMock).toHaveBeenCalledWith('proj');
   });
 
   it('passes repo option to initProject', async () => {
@@ -143,8 +143,7 @@ describe('CLI argument parsing', () => {
       // process.exit throws
     }
 
-    expect(initProjectMock).toHaveBeenCalledWith('myapp', { repoUrl: 'https://example.com/repo.git', branch: undefined, repoUrl: undefined, install: false });
-    expect(createEnvMock).toHaveBeenCalledWith('proj');
+    expect(initProjectMock).toHaveBeenCalledWith('myapp', { branch: undefined, repoUrl: 'https://example.com/repo.git', install: false, worktree: false });
   });
 });
 
@@ -286,7 +285,7 @@ describe('createEnv', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'git',
-      ['clone', 'https://example.com/custom.git', 'proj'],
+      ['clone', 'https://example.com/custom.git', 'proj', '-b', 'main'],
       { stdio: 'inherit' }
     );
   });


### PR DESCRIPTION
## Summary
- allow specifying a repository URL via `--repo`
- pass repo URL through to `initProject`
- document the new option
- test parsing and cloning with custom repo

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68717c3b864083338530efdf031d743f